### PR TITLE
Use server domain pointer when it exists 

### DIFF
--- a/openvpn-install.sh
+++ b/openvpn-install.sh
@@ -404,7 +404,9 @@ WantedBy=multi-user.target" >> /etc/systemd/system/openvpn-iptables.service
 		semanage port -a -t openvpn_port_t -p "$protocol" "$port"
 	fi
 	# If the server is behind NAT, use the correct IP address
-	[[ -n "$public_ip" ]] && ip="$public_ip"
+	[[ -n "$public_ip" ]] && ip="$public_ip"	
+	# If the server has a domain name pointer, use that instead
+	[[ $(host $ip) =~ ^(.*)( domain name pointer )(.*)\.$ ]] && ip="${BASH_REMATCH[3]}"
 	# client-common.txt is created so we have a template to add further users later
 	echo "client
 dev tun


### PR DESCRIPTION
 #782 I propose to enhance the script with one code line that will change the ip address for the pointer domain when it exists. VPS providers normally allow you to reset this to your domain name. Please note that after installation you need to manually change the IP address for your domain in /etc/openvpn/server/client-common.txt